### PR TITLE
fix returning garbage audio from cache after EOF

### DIFF
--- a/core/src/read/read_stream.rs
+++ b/core/src/read/read_stream.rs
@@ -751,8 +751,6 @@ impl<D: Decoder> ReadDiskStream<D> {
 
         // Check if the end of the file was reached.
         if self.playhead() >= self.file_info.num_frames {
-            self.current_block_start_frame = 0;
-            self.current_frame_in_block = 0;
             return Err(ReadError::EndOfFile);
         }
         let mut reached_end_of_file = false;


### PR DESCRIPTION
Once the end of the file is reached, the EndOfFile error should be returned indefinitely until a seek is done. This fixes the bug demonstrated in #10. However, I suspect there may still be another bug lurking because currently without this PR, the playhead gets reset to the start of the file but the contents of the file are no longer read; audio is only returned from the cache.